### PR TITLE
init db refactored, avoiding duplicate insertations

### DIFF
--- a/src/main/java/com/codecool/hccrm/model/RoleEnum.java
+++ b/src/main/java/com/codecool/hccrm/model/RoleEnum.java
@@ -1,0 +1,20 @@
+package com.codecool.hccrm.model;
+
+/**
+ * Created by dorasztanko on 2017.02.19..
+ */
+public enum RoleEnum {
+    ROLE_ADMIN("ROLE_ADMIN"),
+    ROLE_CEO("ROLE_CEO"),
+    ROLE_MANAGER("ROLE_MANAGER");
+
+    private final String role;
+
+    RoleEnum(String role) {
+        this.role = role;
+    }
+
+    public String getRole() {
+        return this.role;
+    }
+}

--- a/src/main/java/com/codecool/hccrm/service/InitDBService.java
+++ b/src/main/java/com/codecool/hccrm/service/InitDBService.java
@@ -1,74 +1,60 @@
-//package com.codecool.hccrm.service;
-//
-//import com.codecool.hccrm.model.Role;
-//import com.codecool.hccrm.model.User;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-//import org.springframework.stereotype.Service;
-//import org.springframework.transaction.annotation.Transactional;
-//
-//import javax.annotation.PostConstruct;
-//import java.util.HashSet;
-//import java.util.Set;
-//
-///**
-// * Created by dorasztanko on 2017.02.13..
-// */
-//@Transactional
-//@Service
-//public class InitDBService {
-//
-//    private final String adminString = "ROLE_ADMIN";
-//    private final String ceoString = "ROLE_CEO";
-//    private final String managerString = "ROLE_MANAGER";
-//    private final String userString = "ROLE_USER";
-//
-//    private final String userEmail = "hccrm.robotkutya@gmail.com";
-//
-//    @Autowired
-//    RoleService roleService;
-//
-//    @Autowired
-//    UserService userService;
-//
-//    @Autowired
-//    private BCryptPasswordEncoder passwordEncoder;
-//
-//    @PostConstruct
-//    private void init() {
-//        Role roleAdmin = new Role(adminString);
-//        roleService.save(roleAdmin);
-//
-//        Role roleCeo = new Role(ceoString);
-//        roleService.save(roleCeo);
-//
-//        Role roleManager = new Role(managerString);
-//        roleService.save(roleManager);
-//
-//        Role roleUser = new Role(userString);
-//        roleService.save(roleUser);
-//
-//        User admin = new User("John", "Smith", userEmail, passwordEncoder.encode("password"), "+36709861178");
-//
-//        Set<Role> roleSet = new HashSet<>();
-//        roleSet.add(roleAdmin);
-//        admin.setRoles(roleSet);
-//        admin.setVerified(Boolean.TRUE);
-//        userService.save(admin);
-//    }
-//
-////    @PreDestroy
-////    private void cleanUp() {
-////        Role admin = roleService.findByName(adminString);
-////        roleService.delete(admin);
-////
-////        Role roleCeo = roleService.findByName(ceoString);
-////        roleService.delete(roleCeo);
-////
-////        Role roleManager = roleService.findByName(managerString);
-////        roleService.delete(roleManager);
-////
-////        User adminUser = userService.findFirstByEmail(userEmail);
-////        userService.delete(adminUser);
-////    }
-//}
+package com.codecool.hccrm.service;
+
+import com.codecool.hccrm.model.Role;
+import com.codecool.hccrm.model.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Created by dorasztanko on 2017. 02. 09..
+ * Last edited by dorasztanko on 2017. 02. 17..
+ */
+@Transactional
+@Service
+public class InitDBService {
+
+    private final String adminString = "ROLE_ADMIN";
+    private final String ceoString = "ROLE_CEO";
+    private final String managerString = "ROLE_MANAGER";
+
+    private final String userEmail = "hccrm.robotkutya@gmail.com";
+
+    @Autowired
+    RoleService roleService;
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @PostConstruct
+    private void init() {
+        if (roleService.findByName("ROLE_ADMIN") == null) {
+            Role roleAdmin = new Role(adminString);
+            roleService.save(roleAdmin);
+
+            User admin = new User("Ádám", "Kocsis", userEmail, passwordEncoder.encode("codecool"), "+36709861178");
+
+            Set<Role> roleSet = new HashSet<>();
+            roleSet.add(roleAdmin);
+            admin.setRoles(roleSet);
+            admin.setVerified(Boolean.TRUE);
+            userService.save(admin);
+        }
+        if (roleService.findByName("ROLE_CEO") == null) {
+            Role roleCeo = new Role(ceoString);
+            roleService.save(roleCeo);
+        }
+        if (roleService.findByName("ROLE_MANAGER") == null) {
+            Role roleManager = new Role(managerString);
+            roleService.save(roleManager);
+        }
+    }
+}

--- a/src/main/java/com/codecool/hccrm/service/InitDBService.java
+++ b/src/main/java/com/codecool/hccrm/service/InitDBService.java
@@ -11,6 +11,10 @@ import javax.annotation.PostConstruct;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.codecool.hccrm.model.RoleEnum.ROLE_ADMIN;
+import static com.codecool.hccrm.model.RoleEnum.ROLE_CEO;
+import static com.codecool.hccrm.model.RoleEnum.ROLE_MANAGER;
+
 /**
  * Created by dorasztanko on 2017. 02. 09..
  * Last edited by dorasztanko on 2017. 02. 17..
@@ -18,10 +22,6 @@ import java.util.Set;
 @Transactional
 @Service
 public class InitDBService {
-
-    private final String adminString = "ROLE_ADMIN";
-    private final String ceoString = "ROLE_CEO";
-    private final String managerString = "ROLE_MANAGER";
 
     private final String userEmail = "hccrm.robotkutya@gmail.com";
 
@@ -36,8 +36,8 @@ public class InitDBService {
 
     @PostConstruct
     private void init() {
-        if (roleService.findByName("ROLE_ADMIN") == null) {
-            Role roleAdmin = new Role(adminString);
+        if (roleService.findByName(ROLE_ADMIN.getRole()) == null) {
+            Role roleAdmin = new Role(ROLE_ADMIN.getRole());
             roleService.save(roleAdmin);
 
             User admin = new User("Ádám", "Kocsis", userEmail, passwordEncoder.encode("codecool"), "+36709861178");
@@ -48,12 +48,12 @@ public class InitDBService {
             admin.setVerified(Boolean.TRUE);
             userService.save(admin);
         }
-        if (roleService.findByName("ROLE_CEO") == null) {
-            Role roleCeo = new Role(ceoString);
+        if (roleService.findByName(ROLE_CEO.getRole()) == null) {
+            Role roleCeo = new Role(ROLE_CEO.getRole());
             roleService.save(roleCeo);
         }
-        if (roleService.findByName("ROLE_MANAGER") == null) {
-            Role roleManager = new Role(managerString);
+        if (roleService.findByName(ROLE_MANAGER.getRole()) == null) {
+            Role roleManager = new Role(ROLE_MANAGER.getRole());
             roleService.save(roleManager);
         }
     }


### PR DESCRIPTION
Dear Teammates!
Please, review my slight refactor. @PostConstruct annotation runs once before every server restart. This class provides to have our 'Role' table prefilled with necessarry role models and it also inserts an admin user into the 'User' table. That specific row (Line #43) unfortunately must be burnt, because it is easier this way right now (deployment makes things a bit more complicated).
Optional solution /instead of burning/:
- read in from gitignored json --- not working on deployment (manual insertation after every single deploy)  

THX!